### PR TITLE
Fix deps badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ Apache License, Version 2.0.
 
 [travis]: https://travis-ci.org/clojusc/mesomatic-examples
 [travis-badge]: https://travis-ci.org/clojusc/mesomatic-examples.png?branch=master
-[deps]: http://jarkeeper.com/clojusc/mesomatic-examples
-[deps-badge]: http://jarkeeper.com/clojusc/mesomatic-examples/status.svg
+[deps]: https://jarkeeper.com/clojusc/mesomatic-examples
+[deps-badge]: https://jarkeeper.com/clojusc/mesomatic-examples/status.svg
 [logo]: resources/images/Apache-Mesos-logo-x250.png
 [logo-large]: resources/images/Apache-Mesos-logo-x1000.png
 [tag-badge]: https://img.shields.io/github/tag/clojusc/mesomatic-examples.svg?maxAge=2592000


### PR DESCRIPTION
This should fix the issue related with badge showing the dependencies out of date.
